### PR TITLE
fix: eslintrc에 linebreak ruls 추가

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,11 @@ module.exports = {
     'import/extensions': 'off',
     'import/no-extraneous-dependencies': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    'linebreak-style': [
+      'error',
+      require('os').EOL === '\r\n' ? 'windows' : 'unix',
+    ],
+    'prettier/prettier': ['error', { endOfLine: 'auto' }],
   },
   ignorePatterns: ['dist/', 'node_modules/'],
 };


### PR DESCRIPTION
### Short description

.eslintrc.js의 rule에 linebreak 관련 설정을 추가하여 windows와 다른 os간의 개행문자 통일

### Proposed changes

- .eslintrc.js에 linebreak-style rule 추가
- .eslintrc.js에 prettier/prettier rule 추가
- 참고 : https://url.kr/mwgoq3

### How to test (Optional)

_How to test this PR_

### Screenshots (Optional)

#### Before this PR

#### After this PR

### Reference (Optional)

_Resolves #16
